### PR TITLE
Remove dependency on mbed-drivers

### DIFF
--- a/module.json
+++ b/module.json
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "mbed-drivers": "*"
+    "cmsis-core": "~0.4.0"
   },
   "targetDependencies": {}
 }

--- a/source/benchmark.cpp
+++ b/source/benchmark.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void uvisor_benchmark_configure(void)

--- a/source/error.cpp
+++ b/source/error.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void uvisor_error(THaltUserError reason)

--- a/source/interrupts.cpp
+++ b/source/interrupts.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed/mbed.h"
 #include "uvisor-lib/uvisor-lib.h"
 
 void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag)

--- a/uvisor-lib/uvisor-lib.h
+++ b/uvisor-lib/uvisor-lib.h
@@ -20,8 +20,7 @@
 #include <stdint.h>
 
 /* needed for NVIC symbols */
-/* #include "cmsis-core/cmsis_nvic.h" */
-#include "cmsis_nvic.h"
+#include "cmsis-core/cmsis_nvic.h"
 
 /* the symbol UVISOR_PRESENT is defined here based on the supported platforms */
 #include "uvisor-lib/platforms.h"


### PR DESCRIPTION
cmsis-core is a much lower level dependency, used only to provide fallback NVIC functions and symbols