### PR TITLE
fix missing benchmark header

### DIFF
--- a/source/benchmark.cpp
+++ b/source/benchmark.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "uvisor-lib/uvisor-lib.h"
+#include "uvisor-lib/benchmark.h"
 
 void uvisor_benchmark_configure(void)
 {

--- a/source/interrupts.cpp
+++ b/source/interrupts.cpp
@@ -16,6 +16,8 @@
  */
 #include "uvisor-lib/uvisor-lib.h"
 
+#ifdef YOTTA_CFG_UVISOR_PRESENT
+
 void vIRQ_SetVectorX(uint32_t irqn, uint32_t vector, uint32_t flag)
 {
     if(__uvisor_mode == 0) {
@@ -136,3 +138,6 @@ int vIRQ_GetLevel(void)
         return UVISOR_SVC(UVISOR_SVC_ID_IRQ_LEVEL_GET, "");
     }
 }
+
+#endif
+


### PR DESCRIPTION
Without this patch, my build dies like this

/home/agreen/projects/mbed/mbed-client-examples/yotta_modules/uvisor-lib/source/benchmark.cpp: In function 'void uvisor_benchmark_configure()':
/home/agreen/projects/mbed/mbed-client-examples/yotta_modules/uvisor-lib/source/benchmark.cpp:28:28: error: 'uvisor_benchmark_start' was not declared in this scope
     uvisor_benchmark_start();
                            ^
In file included from /home/agreen/projects/mbed/mbed-client-examples/yotta_modules/uvisor-lib/uvisor-lib/uvisor-lib.h:26:0,
                 from /home/agreen/projects/mbed/mbed-client-examples/yotta_modules/uvisor-lib/source/benchmark.cpp:17:
/home/agreen/projects/mbed/mbed-client-examples/yotta_modules/uvisor-lib/source/benchmark.cpp:29:71: error: 'uvisor_benchmark_stop' was not declared in this scope
     UVISOR_SVC(UVISOR_SVC_ID_BENCHMARK_CFG, "", uvisor_benchmark_stop());
