### PR TITLE
Throw error at inconsistent UVISOR_PRESENT settings

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -41,11 +41,11 @@ if(UVISOR_PRESENT)
     )
 else()
     message(WARNING
-"\n         *******************************************************************
-         * WARNING (uvisor-lib): unsupported platform; your code will still
-         *                       work but no security feature is provided;
-         *                       UVISOR_DISABLED is set by default
-         *******************************************************************")
+"\n         *********************************************************************
+         * WARNING (uvisor-lib): unsupported platform; your code will still  *
+         *                       work but no security feature is provided;   *
+         *                       UVISOR_DISABLED is set by default           *
+         *********************************************************************")
     add_library(uvisor-lib
         "unsupported.cpp"
     )

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -49,4 +49,21 @@ else()
     add_library(uvisor-lib
         "unsupported.cpp"
     )
+
+    # check that the yotta config option has not been mistakenly changed
+    if((DEFINED YOTTA_CFG_UVISOR_PRESENT) AND ("${YOTTA_CFG_UVISOR_PRESENT}" STREQUAL "1"))
+        message(FATAL_ERROR
+"\n         *********************************************************************
+         * ERROR   (uvisor-lib): this is an unsupported platform, but        *
+         *                             yotta config \"uvisor.present\"         *
+         *                       is set to 1; please contact the target      *
+         *                       owner to set it to 0 while uVisor is not    *
+         *                       officially supported.                       *
+         *                       You can apply the config option as a        *
+         *                       temporary fix in your executable:           *
+         *                                                                   *
+         *                yotta --config='{\"uvisor\":{\"present\": 0}}' build   *
+         *                                                                   *
+         *********************************************************************")
+    endif()
 endif()


### PR DESCRIPTION
The `UVISOR_PRESENT` variable is set by the uvisor-lib `CMakeLists.txt`
file for its internal use, and it's based on the actual list of officially
supported platforms.

Targets, on the other hand, need to define a yotta config variable:
`YOTTA_CFG_UVISOR_PRESENT`
to confirm that uVisor has been ported and it is now supported on that
platform.

This commit adds a sanity check on the consistency between
`CMakeLists.txt::UVISOR_PRESENT` and `YOTTA_CFG_UVISOR_PRESENT`. It will prevent
copy-paste mistakes that are likely to be made when using an existing config
file as a starting point for a new target.

@meriac 
@Patater 
@autopulated 
This addresses [this issue](http://forums.mbed.com/t/nucleo-f410re-yotta-build-error/1038)