### PR TITLE
Change conditional inclusion of device family

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -22,7 +22,7 @@
 set(UVISOR_SUPPORTED false)
 if(TARGET_LIKE_GCC)
     # Pick the correct folder based on the target family.
-    if(TARGET_LIKE_KINETIS_K64_GCC)
+    if(TARGET_LIKE_KINETIS)
         set(UVISOR_FAMILY "kinetis")
     elseif(TARGET_LIKE_STM32)
         set(UVISOR_FAMILY "stm32")


### PR DESCRIPTION
This change introduces what was the originally intended `TARGET_LIKE_*`
specification for the `kinetis` family. The change was waiting for
ARMmbed/target-kinetis-k64-gcc@942596a ("Add family "similar to" key in target.json").

@meriac @Patater 